### PR TITLE
Enable IPv6 support

### DIFF
--- a/server.py
+++ b/server.py
@@ -101,6 +101,6 @@ print
 #reactor.listenTCP( 80, server.Site(Root))
 #reactor.listenTCP( 80, server.Site(util.Redirect("https://192.168.0.10")))
 #reactor.listenTCP(443, server.Site(Root), ssl.DefaultOpenSSLContextFactory("server.key", "server.crt"))
-reactor.listenTCP(800, server.Site(Root))
+reactor.listenTCP(80, server.Site(Root), interface='::')
 
 reactor.run()


### PR DESCRIPTION
On Linux, a socket listening on `::` will also listen on IPv4. IPv4 addresses are mapped to IPv6 by prefixing them with `::ffff:` (but the rest of the address is dotted like IPv4). Note that this does not happen by default on other systems, such as BSD, OS X and Windows.
